### PR TITLE
add config option to transform each message

### DIFF
--- a/script.js
+++ b/script.js
@@ -95,13 +95,14 @@
       var filters = options.filters || options.filter || {};
       var limit = options.limit || null;
       var raw = options.raw || false;
+      var transform = options.transform;
       var msgs = messages;
 
       if (limit) {
         msgs = msgs.slice(-1*limit);
       }
 
-      return msgs.map((msg) => {
+      var results = msgs.map((msg) => {
         if (!keep(msg, filters)) {
           return;
         }
@@ -110,7 +111,14 @@
         }
         return columns.map((c) => msg[c]);
       })
-        .filter((row) => !!row) // remove filtered rows
+        .filter((row) => !!row); // remove filtered rows
+      if (typeof transform !== 'function') {
+        return results;
+      }
+      return results.map((row) => {
+        row.msg = transform(row.msg);
+        return row;
+      });    
     },
 
     pretty(options) {


### PR DESCRIPTION
This is useful for transforming encoded or wrapped messages so they're easier to see in the logs (i.e., my usecase is that xml comes in wrapped in a socket.io payload, so a simple transform rips the xml out, so the xml pretty printer works.
